### PR TITLE
New variables: pg_hba_add_allow_all and postgresql_pg_hba_auth_method

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Role Variables
 - **postgresql_certificate_key_file** - path to private key
 - **postgresql_certificate_chain_file** - path to CA certificate chain
 - **postgresql_pgwatch_password** - if defined, user pgwatch with connect privilege is created and extension pg_stat_statements is added
+- **postgresql_pg_hba_add_allow_all** when set to false, pg_hba.conf entry allowing all connections isn't added.
+- **postgresql_pg_hba_auth_method** allows changing the auth method for the pg_hba added by this role, default is md5 (for backward compatibility).
         
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,5 @@ postgresql_daily_backup_more_commands: ""
 postgresql_allow_remote_connections: yes
 
 postgresql_settings: {}
+postgresql_pg_hba_add_allow_all: true
+postgresql_pg_hba_auth_method: md5 # update to scram-sha-256 for additional password protection of remote authentication

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,7 @@ galaxy_info:
         - buster
         - bullseye
         - bookworm
+        - trixie
     - name: RedHat
       versions:
         - 7

--- a/tasks/postgresql_install_Debian.yml
+++ b/tasks/postgresql_install_Debian.yml
@@ -82,5 +82,6 @@
     databases: all
     users: all
     address: all
-    method: md5
+    method: "{{ postgresql_pg_hba_auth_method }}"
+  when: postgresql_pg_hba_add_allow_all
   notify: "restart postgresql"

--- a/tasks/postgresql_install_RedHat.yml
+++ b/tasks/postgresql_install_RedHat.yml
@@ -60,5 +60,6 @@
     databases: all
     users: all
     address: all
-    method: md5
+    method: "{{ postgresql_pg_hba_auth_method }}"
+  when: postgresql_pg_hba_add_allow_all
   notify: "restart postgresql"


### PR DESCRIPTION
Allow setting-up cluster, which won't allow connecting all hosts to all DBs via pg_hba.
Allow customizing the authentication method (can be changed to scram-sha-256).

Default behavior of the role remains unchanged.